### PR TITLE
Update boulder and its setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 services:
   - rabbitmq
 script:
-  - pytest
+  - py.test
   - tests/integration/register.sh
   - tests/integration/gencert.py
 after_script: cat ~/build/go/src/github.com/letsencrypt/boulder/nohup.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
   - py.test
   - tests/integration/register.sh
   - tests/integration/gencert.py
-after_script: cat ~/build/go//src/github.com/letsencrypt/boulder/nohup.out
+after_script: cat ~/build/go/src/github.com/letsencrypt/boulder/nohup.out
 deploy:
   provider: pypi
   user: mswart

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ install:
 services:
   - rabbitmq
 script:
-  - py.test
-  - tests/integration/register.sh
-  - tests/integration/gencert.py
+  - pytest --tb=line
+  #- tests/integration/register.sh
+  #- tests/integration/gencert.py
 after_script: cat ~/build/go/src/github.com/letsencrypt/boulder/nohup.out
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - '3.3'
-  - '3.4'
+#  - '3.3'
+#  - '3.4'
   - '3.5'
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-#  - '3.3'
-#  - '3.4'
+  - '3.3'
+  - '3.4'
   - '3.5'
 sudo: required
 dist: trusty
@@ -12,9 +12,9 @@ install:
 services:
   - rabbitmq
 script:
-  - pytest --tb=line
-  #- tests/integration/register.sh
-  #- tests/integration/gencert.py
+  - pytest
+  - tests/integration/register.sh
+  - tests/integration/gencert.py
 after_script: cat ~/build/go/src/github.com/letsencrypt/boulder/nohup.out
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
   - sudo tests/scripts/setup-dependencies.sh
   - tests/scripts/setup-boulder.sh
   - pip install -r requirements.txt
+services:
+  - rabbitmq
 script:
   - py.test
   - tests/integration/register.sh

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -4,7 +4,7 @@ eval "$(gimme 1.6)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
-git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
+git clone git://github.com/letsencrypt/boulder.git --branch hotfixes/2016-06-30 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -9,8 +9,9 @@ cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 make
+# we need to install goose now, otherwise the test/create_db.sh call in test/setup.sh will be called before goose is installed
+go get -v bitbucket.org/liamstask/goose/cmd/goose
 ./test/setup.sh
-./test/create_db.sh
 nohup python2.7 start.py &
 sleep 2
 cat nohup.out

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -6,7 +6,6 @@ export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/b
 mkdir -p $GOPATH/src/github.com/letsencrypt/
 git clone git://github.com/letsencrypt/boulder.git --branch hotfixes/2016-06-30 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
-#sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 
 go get -v \

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -4,7 +4,7 @@ eval "$(gimme 1.5)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
-git clone git://github.com/letsencrypt/boulder.git --branch release-2015-12-07 $GOPATH/src/github.com/letsencrypt/boulder
+git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
 sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -x
-eval "$(gimme 1.5)"
+eval "$(gimme 1.6)"
 export GOPATH=~/build/go
-export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin
+export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
 git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
@@ -11,5 +11,7 @@ sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 make
 go install -v ./...
 ./test/setup.sh
+make
+go install -v ./...
 nohup python2.7 start.py &
 sleep 2

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -6,9 +6,9 @@ export PATH=$PATH:$GOPATH/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
 git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
-sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
-sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
-./test/setup.sh
+#sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
+sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh || true
+./test/setup.sh || true
 go install -v ./...
 nohup python2.7 start.py &
 sleep 2

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -4,7 +4,7 @@ eval "$(gimme 1.6)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
-git clone git://github.com/letsencrypt/boulder.git --branch hotfixes/2016-06-30 $GOPATH/src/github.com/letsencrypt/boulder
+git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 eval "$(gimme 1.5)"
+echo "$(gimme 1.5)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
@@ -8,7 +9,8 @@ git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $
 cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh || true
-./test/setup.sh || true
+go get -t ./...
 go install -v ./...
+./test/setup.sh || true
 nohup python2.7 start.py &
 sleep 2

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -ex
 eval "$(gimme 1.6)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/bin
@@ -9,9 +9,8 @@ cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 make
-go install -v ./...
 ./test/setup.sh
-make
-go install -v ./...
+./test/create_db.sh
 nohup python2.7 start.py &
 sleep 2
+cat nohup.out

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -8,10 +8,24 @@ git clone git://github.com/letsencrypt/boulder.git --branch hotfixes/2016-06-30 
 cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
-make
-# we need to install goose now, otherwise the test/create_db.sh call in test/setup.sh will be called before goose is installed
-go get -v bitbucket.org/liamstask/goose/cmd/goose
-./test/setup.sh
+
+go get -v \
+  bitbucket.org/liamstask/goose/cmd/goose \
+  github.com/golang/lint/golint \
+  github.com/golang/mock/mockgen \
+  github.com/golang/protobuf/proto \
+  github.com/golang/protobuf/protoc-gen-go \
+  github.com/jsha/listenbuddy \
+  github.com/kisielk/errcheck \
+  github.com/mattn/goveralls \
+  github.com/modocache/gover \
+  github.com/tools/godep \
+  golang.org/x/tools/cover
+
+go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq
+
+./test/create_db.sh
+
 nohup python2.7 start.py &
 sleep 2
 cat nohup.out

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -22,6 +22,8 @@ go get -v \
   github.com/tools/godep \
   golang.org/x/tools/cover
 
+make GO_BUILD_FLAGS=''
+
 go run cmd/rabbitmq-setup/main.go -server amqp://boulder-rabbitmq
 
 ./test/create_db.sh

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -4,7 +4,7 @@ eval "$(gimme 1.6)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin:~/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
-git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
+git clone git://github.com/letsencrypt/boulder.git --branch hotfixes/2016-06-30 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-set -ex
+set -x
 eval "$(gimme 1.5)"
 echo "$(gimme 1.5)"
 export GOPATH=~/build/go
-export PATH=$PATH:$GOPATH/bin
+export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
 git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $GOPATH/src/github.com/letsencrypt/boulder
 cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
-sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh || true
+sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
 go get -t ./...
 go install -v ./...
-./test/setup.sh || true
+./test/setup.sh
 nohup python2.7 start.py &
 sleep 2

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -x
 eval "$(gimme 1.5)"
-echo "$(gimme 1.5)"
 export GOPATH=~/build/go
 export PATH=$PATH:$GOPATH/bin:$GOPATH/src/github.com/letsencrypt/boulder/bin
 mkdir -p $GOPATH/src/github.com/letsencrypt/
@@ -9,7 +8,7 @@ git clone git://github.com/letsencrypt/boulder.git --branch release-2016-07-14 $
 cd $GOPATH/src/github.com/letsencrypt/boulder
 #sed -i -e 's/root@tcp/boulder:test@tcp/' policy/_db/dbconf.yml sa/_db/dbconf.yml
 sed -i -e 's/-u root/-u boulder -ptest/' test/create_db.sh
-go get -t ./...
+make
 go install -v ./...
 ./test/setup.sh
 nohup python2.7 start.py &

--- a/tests/scripts/setup-dependencies.sh
+++ b/tests/scripts/setup-dependencies.sh
@@ -15,4 +15,4 @@ GRANT ALL PRIVILEGES ON *.* TO 'boulder'@'%' with grant option;
 FLUSH PRIVILEGES;
 EOF
 # define boulder needed hostnames
-gawk -i inplace '/^127.0.0.1:/ {$0=$0" boulder-mysql boulder-rabbitmq"}' /etc/hosts
+sed --in-place -e '/^127.0.0.1/ s/$/ boulder-mysql boulder-rabbitmq/' /etc/hosts

--- a/tests/scripts/setup-dependencies.sh
+++ b/tests/scripts/setup-dependencies.sh
@@ -2,7 +2,7 @@
 set -ex
 # add ppa for mariadb and rabbitmq (needs newer versions)
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
-echo 'deb http://mirror2.hs-esslingen.de/mariadb/repo/10.1/ubuntu trusty main' > /etc/apt/sources.list.d/mariadb.list
+echo 'deb http://sfo1.mirrors.digitalocean.com//mariadb/repo/10.1/ubuntu trusty main' > /etc/apt/sources.list.d/mariadb.list
 # update package list
 apt-get update
 # install packages

--- a/tests/scripts/setup-dependencies.sh
+++ b/tests/scripts/setup-dependencies.sh
@@ -2,11 +2,11 @@
 set -ex
 # add ppa for mariadb and rabbitmq (needs newer versions)
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
-echo 'deb http://mirror2.hs-esslingen.de/mariadb/repo/10.0/ubuntu trusty main' > /etc/apt/sources.list.d/mariadb.list
+echo 'deb http://mirror2.hs-esslingen.de/mariadb/repo/10.1/ubuntu trusty main' > /etc/apt/sources.list.d/mariadb.list
 # update package list
 apt-get update
 # install packages
-apt-get install -yV libltdl-dev mariadb-server mariadb-server-10.0 python2.7
+apt-get install -yV libltdl-dev mariadb-server mariadb-server-10.1 python2.7
 # configure mariadb
 # todo
 mysql -u root <<EOF

--- a/tests/scripts/setup-dependencies.sh
+++ b/tests/scripts/setup-dependencies.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -ex
 # add ppa for mariadb and rabbitmq (needs newer versions)
-apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db 0xe49303a769479fee
 echo 'deb http://sfo1.mirrors.digitalocean.com//mariadb/repo/10.1/ubuntu trusty main' > /etc/apt/sources.list.d/mariadb.list
+echo 'deb http://ppa.launchpad.net/5-james-t/protobuf-ppa/ubuntu trusty main' > /etc/apt/sources.list.d/protobuf.list
 # update package list
 apt-get update
 # install packages
-apt-get install -yV libltdl-dev mariadb-server mariadb-server-10.1 python2.7
+apt-get install -yV libltdl-dev mariadb-server mariadb-server-10.1 python2.7 libprotobuf-dev protobuf-compiler
 # configure mariadb
 # todo
 mysql -u root <<EOF
@@ -15,4 +16,4 @@ GRANT ALL PRIVILEGES ON *.* TO 'boulder'@'%' with grant option;
 FLUSH PRIVILEGES;
 EOF
 # define boulder needed hostnames
-sed --in-place -e '/^127.0.0.1/ s/$/ boulder-mysql boulder-rabbitmq/' /etc/hosts
+sed --in-place -e '/^127.0.0.1/ s/$/ boulder boulder-mysql boulder-rabbitmq/' /etc/hosts

--- a/tests/scripts/setup-dependencies.sh
+++ b/tests/scripts/setup-dependencies.sh
@@ -14,3 +14,5 @@ CREATE USER boulder IDENTIFIED by "test";
 GRANT ALL PRIVILEGES ON *.* TO 'boulder'@'%' with grant option;
 FLUSH PRIVILEGES;
 EOF
+# define boulder needed hostnames
+gawk -i inplace '/^127.0.0.1:/ {$0=$0" boulder-mysql boulder-rabbitmq"}' /etc/hosts

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -129,7 +129,7 @@ def test_rate_limit_on_certificate_creation(registered_account_dir, http_server,
     m = server.ACMEAbstractHandler.manager = MA(registered_account_dir, validator=http_server)
     authzrs = m.acquire_domain_validations(http_server, domains)
     assert len(authzrs) is 1
-    for i in range(2):
+    for i in range(6):
         certs = m.issue_certificate(csr, authzrs)
         assert len(certs) == 2
     with pytest.raises(exceptions.RateLimited) as e:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -128,7 +128,7 @@ def test_mgmt_reject_correct_ip_but_wrong_hmac_type(http_server, mgmt_server, ck
 
 
 @pytest.mark.boulder
-def test_mgmt_reject_to_long_csr(registered_account_dir, http_server, mgmt_server, ckey):
+def test_mgmt_reject_too_long_csr(registered_account_dir, http_server, mgmt_server, ckey):
     server.ACMEAbstractHandler.manager = M('''
         [account]
         dir = {}


### PR DESCRIPTION
Move to newer boulder release.

This requires same changed dependencies and other setup adjustments. To improve setup times we use protobuf (precompiled) debs.