### PR TITLE
Update supported python versions

### DIFF
--- a/.github/workflows/push+deploy.yml
+++ b/.github/workflows/push+deploy.yml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8
+          - 3.9
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -38,10 +38,10 @@ jobs:
           - pebble
           - boulder
         python-version:
-          - 3.5
           - 3.6
           - 3.7
           - 3.8
+          - 3.9
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -273,6 +273,13 @@ The server is tested by unit tests, integration tests against test ACME servers 
 The test are exectued by `py.test`. `docker-compose` is used to run the ACME servers. Take a look at `tests/scripts` to inspect the commands, that are run as part of the CI.
 
 
+## Support
+
+The goal is to be compatible with all supported Python versions. But adjusting the CI and publishing a new release might take some time. This primarily means that removing support for a EOL Python version is not considered a breaking change and will happen in normal minor releases (but not in patch/bug-fix releases).
+
+Recently new dependency version are expected. This is difficult to pin-point at the moment, but the idea is to be compatible with the version from the latest Ubuntu LTS and Debian releases. The minimal dependency versions are tried to express. But as the CI does not run tests for all existing versions, they could be slightly out-of-date from time to time.
+
+
 ## Contributing
 
 1. Fork it

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Remove EOL Python 3.5 and add newly released Python 3.9. Add a README
sections about the update policy of supported Python versions.