### PR TITLE
Use cryptography to parse certificate signing request (CSR)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,7 @@ name = "acme-mgmtserver"
 version = "0.5.0a1"
 requires-python = ">=3.10"
 license = "GPL-3.0-or-later"
-dependencies = [
-  "acme>=0.21.0",
-  "josepy",
-  "PyOpenSSL",    # >=2017.1.0",  # to_cryptography (>=2017.1.0)
-  "IPy",
-]
+dependencies = ["acme>=0.21.0", "josepy", "IPy"]
 description = "Basic Python Server to execute ACME on behalf of dumb clients"
 readme = "README.md"
 authors = [{ name = "Malte Swart", email = "mswart@devtation.de" }]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization as pem_serialization
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes
-from cryptography.x509 import CertificateSigningRequest
+from cryptography.x509 import Certificate, CertificateSigningRequest
 from cryptography.x509.extensions import Extension, SubjectAlternativeName
 from cryptography.x509.oid import ExtensionOID, NameOID
 
@@ -101,11 +101,11 @@ def signcsr(
     )
 
 
-def extract_alt_names(csr: CertificateSigningRequest) -> list[str]:
+def extract_alt_names(cert: Certificate) -> list[str]:
     try:
         extension = cast(
             Extension[SubjectAlternativeName],
-            csr.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME),
+            cert.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME),
         )
         return extension.value.get_values_for_type(x509.DNSName)
     except x509.ExtensionNotFound:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import urllib.error
 import urllib.request
 
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes
-from cryptography.x509 import load_pem_x509_csr
+from cryptography.x509 import load_pem_x509_certificates
 import pytest
 
 from acmems import challenges, server
@@ -253,8 +253,8 @@ def test_mgmt_complete_multiple_domains(
     response = urllib.request.urlopen(request)
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [load_pem_x509_csr(cert) for cert in certs]
-    assert sorted(extract_alt_names(x509[0])) == sorted(domains)
+    parsed_certs = load_pem_x509_certificates(certs)
+    assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
 def test_mgmt_complete_one_domain(
@@ -271,8 +271,8 @@ def test_mgmt_complete_one_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [load_pem_x509_csr(cert) for cert in certs]
-    assert sorted(extract_alt_names(x509[0])) == sorted(domains)
+    parsed_certs = load_pem_x509_certificates(certs)
+    assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
 def test_mgmt_complete_one_domain_by_dns(
@@ -300,8 +300,8 @@ def test_mgmt_complete_one_domain_by_dns(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [load_pem_x509_csr(cert) for cert in certs]
-    assert sorted(extract_alt_names(x509[0])) == sorted(domains)
+    parsed_certs = load_pem_x509_certificates(certs)
+    assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
 def test_mgmt_complete_wildcard_domain(
@@ -329,8 +329,8 @@ def test_mgmt_complete_wildcard_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [load_pem_x509_csr(cert) for cert in certs]
-    assert sorted(extract_alt_names(x509[0])) == sorted(domains)
+    parsed_certs = load_pem_x509_certificates(certs)
+    assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
 def test_mgmt_for_certificate_error(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import urllib.error
 import urllib.request
 
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes
-from OpenSSL import crypto
+from cryptography.x509 import load_pem_x509_csr
 import pytest
 
 from acmems import challenges, server
@@ -253,10 +253,7 @@ def test_mgmt_complete_multiple_domains(
     response = urllib.request.urlopen(request)
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [crypto.load_certificate(crypto.FILETYPE_PEM, cert) for cert in certs]
-    # assert x509[0].get_issuer() == x509[1].get_subject()
-    assert x509[0].has_expired() is False
-    assert x509[1].has_expired() is False
+    x509 = [load_pem_x509_csr(cert) for cert in certs]
     assert sorted(extract_alt_names(x509[0])) == sorted(domains)
 
 
@@ -274,10 +271,7 @@ def test_mgmt_complete_one_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [crypto.load_certificate(crypto.FILETYPE_PEM, cert) for cert in certs]
-    # assert x509[0].get_issuer() == x509[1].get_subject()
-    assert x509[0].has_expired() is False
-    assert x509[1].has_expired() is False
+    x509 = [load_pem_x509_csr(cert) for cert in certs]
     assert sorted(extract_alt_names(x509[0])) == sorted(domains)
 
 
@@ -306,10 +300,7 @@ def test_mgmt_complete_one_domain_by_dns(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [crypto.load_certificate(crypto.FILETYPE_PEM, cert) for cert in certs]
-    # assert x509[0].get_issuer() == x509[1].get_subject()
-    assert x509[0].has_expired() is False
-    assert x509[1].has_expired() is False
+    x509 = [load_pem_x509_csr(cert) for cert in certs]
     assert sorted(extract_alt_names(x509[0])) == sorted(domains)
 
 
@@ -338,10 +329,7 @@ def test_mgmt_complete_wildcard_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    x509 = [crypto.load_certificate(crypto.FILETYPE_PEM, cert) for cert in certs]
-    # assert x509[0].get_issuer() == x509[1].get_subject()
-    assert x509[0].has_expired() is False
-    assert x509[1].has_expired() is False
+    x509 = [load_pem_x509_csr(cert) for cert in certs]
     assert sorted(extract_alt_names(x509[0])) == sorted(domains)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,7 @@ import urllib.error
 import urllib.request
 
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes
-from cryptography.x509 import load_pem_x509_certificates
+from cryptography.x509 import load_pem_x509_certificate
 import pytest
 
 from acmems import challenges, server
@@ -253,7 +253,7 @@ def test_mgmt_complete_multiple_domains(
     response = urllib.request.urlopen(request)
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    parsed_certs = load_pem_x509_certificates(certs)
+    parsed_certs = [load_pem_x509_certificate(cert) for cert in certs]
     assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
@@ -271,7 +271,7 @@ def test_mgmt_complete_one_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    parsed_certs = load_pem_x509_certificates(certs)
+    parsed_certs = [load_pem_x509_certificate(cert) for cert in certs]
     assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
@@ -300,7 +300,7 @@ def test_mgmt_complete_one_domain_by_dns(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    parsed_certs = load_pem_x509_certificates(certs)
+    parsed_certs = [load_pem_x509_certificate(cert) for cert in certs]
     assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 
@@ -329,7 +329,7 @@ def test_mgmt_complete_wildcard_domain(
     )
     certs = response.read().split(b"\n\n")
     assert len(certs) == 2
-    parsed_certs = load_pem_x509_certificates(certs)
+    parsed_certs = [load_pem_x509_certificate(cert) for cert in certs]
     assert sorted(extract_alt_names(parsed_certs[0])) == sorted(domains)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,6 @@ dependencies = [
     { name = "acme" },
     { name = "ipy" },
     { name = "josepy" },
-    { name = "pyopenssl" },
 ]
 
 [package.optional-dependencies]
@@ -52,7 +51,6 @@ requires-dist = [
     { name = "ipy" },
     { name = "josepy" },
     { name = "py3dns", marker = "extra == 'dns01'" },
-    { name = "pyopenssl" },
     { name = "systemd", marker = "extra == 'systemd'" },
 ]
 provides-extras = ["systemd", "dns01"]


### PR DESCRIPTION
PyOpenSSL deprecated its functions and recommends using cryptography.