### PR TITLE
ci: Reenable Python 3.13 for integration tests

### DIFF
--- a/.github/workflows/push+deploy.yml
+++ b/.github/workflows/push+deploy.yml
@@ -63,7 +63,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          # - "3.13" (ssl connection issues to pebble due to strict ssl cert verification)
+          - "3.13"
       fail-fast: false
 
     steps:

--- a/tests/scripts/setup-boulder.sh
+++ b/tests/scripts/setup-boulder.sh
@@ -14,7 +14,7 @@ docker compose up -d
 echo 'waiting for boulder to be functional ...'
 
 while true; do
-  curl http://127.0.0.1:4001/directory && break
+  curl --silent --show-error http://127.0.0.1:4001/directory && break
   sleep 1
   if [[ "$SECONDS" -gt 300 ]]; then
     echo 'setup took more than 5 minutes, give up  :-('


### PR DESCRIPTION
The new pebble certs are now compatible with Python 3.13's strict SSL checking.